### PR TITLE
fix terminal consonant rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,26 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Chakobsa Renderer</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="css/style.css" rel="stylesheet">
-  </head>
-  <script>
-    setInterval(() => {document.getElementById("rendered").innerHTML = document.getElementById("romanized").value}, 1000);
-  </script>
-  <body>
-    <div class="container">
-      <h1 class="pagetitle"><em>Dinlih</em> Renderer</h1>
-      <h3 class="pagesubtitle">Dinlih</h3>
-      <textarea id="romanized">Sa fadla .</textarea><br>
-      <p id="rendered"></p>
-      <p class="footer">
-        Made with ❤️ by <a href="https://github.com/mixolydianmel/">Melody</a>
-      </p>
-    </div>
-  </body>
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chakobsa Renderer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet">
+  <link href="css/style.css" rel="stylesheet">
+</head>
+<script>
+  setInterval(() => { document.getElementById("rendered").innerHTML = (document.getElementById("romanized").value + ' ').replaceAll(' ', ' &nbsp; ') }, 1000);
+</script>
+
+<body>
+  <div class="container">
+    <h1 class="pagetitle"><em>Dinlih</em> Renderer</h1>
+    <h3 class="pagesubtitle">Dinlih Ruzam</h3>
+    <textarea id="romanized">Sa fadla .</textarea><br>
+    <p id="rendered"></p>
+    <p class="footer">
+      Made with ❤️ by <a href="https://github.com/mixolydianmel/">Melody</a>
+    </p>
+  </div>
+</body>
+
 </html>


### PR DESCRIPTION
Add a non-breaking space to any user input for correct rendering.

This Chakobsa font won't render terminal consonants correctly unless there is whitespace character after the final glyph.  This change appends a literal space character after the contents of `#romanized`, then replaces all spaces with an `&nbsp;` HTML entity so the whitespace is preserved when copied into `#rendered`.